### PR TITLE
fix: export of rts.css

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -44,9 +44,6 @@
       "require": "./dist/react-tabs-scrollable.umd.js",
       "types": "./dist/index.d.ts"
     },
-    "./dist/rts.css": {
-      "import": "./dist/rts.css",
-      "require": "./dist/rts.css"
-    }
+    "./dist/rts.css": "./dist/rts.css"
   }
 }


### PR DESCRIPTION
Thanks for the nice library 👋 

When importing the styles from a CSS file like so `@import 'react-tabs-scrollable/dist/rts.css';`, webpack failed because of how the exports were made in the package.json.

```
ERROR in ./src/index.css (./node_modules/.pnpm/css-loader@6.7.3_webpack@5.79.0_@swc+core@1.5.7_esbuild@0.24.0_/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].use[1]!./src/index.css)
Module build failed (from ./node_modules/.pnpm/css-loader@6.7.3_webpack@5.79.0_@swc+core@1.5.7_esbuild@0.24.0_/node_modules/css-loader/dist/cjs.js):
Error: Package path ./dist/rts.css is not exported from package /<project_path>/node_modules/react-tabs-scrollable (see exports field in /<project_path>/node_modules/react-tabs-scrollable/package.json)
```

In this PR you can find the tested fix for this error. Thanks in advance.

EDIT: Importing `import 'react-tabs-scrollable/dist/rts.css';` in a TSX file, will still work.